### PR TITLE
Fix saving and sending project

### DIFF
--- a/gpao/builder.py
+++ b/gpao/builder.py
@@ -76,3 +76,17 @@ class Builder:
                   exception)
 
         Project.reset()
+
+    def send_project_and_save(self, base_url_api, file_json):
+        self.send_project_to_api(base_url_api)
+
+        json_gpao = {"projects": self.projects}
+        with open(file_json, "w", encoding="utf-8") as fjson:
+            json.dump(
+                json_gpao,
+                fjson,
+                default=handler,
+                ensure_ascii=False,
+                indent=4
+                )
+

--- a/gpao/project.py
+++ b/gpao/project.py
@@ -83,7 +83,7 @@ class Project:
                 return cpt
             cpt += 1
 
-        return -1
+        raise ValueError(f"No job match for job_id = {job_id}")
 
     def to_json(self):
         """ Convert to json """

--- a/test.py
+++ b/test.py
@@ -47,3 +47,16 @@ builder = Builder([project4, project5])
 
 # builder.save_as_json("project2.json")
 builder.send_project_to_api("http://localhost:8080")
+
+
+job10 = Job("job10", "touch file")
+job10bis = Job("job10bis", "touch file", job10)
+project6 = Project("project6",  [job10, job10bis])
+
+job11 = Job("job11", "touch file")
+project7 = Project("project7",  [job11], [project6])
+
+builder = Builder([project6, project7])
+
+# builder.save_as_json("project2.json")
+builder.send_project_and_save("http://localhost:8080", "project1.json")


### PR DESCRIPTION
Proposition de correctif pour le cas d'usage : `builder.save_as_json` + `builder.send_to_api`
au passage, project.find_job_index renvoie une erreur quand aucun job n'est trouvé (facilite le debug)